### PR TITLE
Switch to client-go port forward

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,14 +62,16 @@ This tool reads configuration from a **TOML file**.
 ### **Example Configuration (`config.toml`)**
 ```toml
 global_kubeconfig = "/home/user/.kube/config"
+default_address = "0.0.0.0"
 
 [[context]]
 name = "kind-local"
-address = "0.0.0.0"
 kubeconfig = "/path/to/kubeconfig"
+# address = "127.0.0.1" # optional per context
 
 [[context.svc]]
 name = "mqtt"
+# address = "127.0.0.1" # optional per service
 ports = [{ source = "8883", target = "8883" }, { source = "1883", target = "1883" }]
 
 [[context.pods]]
@@ -148,3 +150,4 @@ go run main.go --debug
 🚀 **Basant Besra**
 📧 besrabasant@gmail.com  
 🐙 [GitHub](https://github.com/besrabasant)
+

--- a/sample.config.toml
+++ b/sample.config.toml
@@ -1,10 +1,19 @@
+# Example configuration
+
 global_kubeconfig = "/home/user/.kube/config"
+# Global bind address if not specified elsewhere
+default_address = "0.0.0.0"
 
 [[context]]
 name = "kind-master"
-address = "0.0.0.0"
 namespace = "default"
+# address = "127.0.0.1" # optional per-context
 
 [[context.svc]]
 name = "mqtt"
-ports = [{ source = "8883", target = "8883" }, { source = "1883", target = "1883" }]
+# address = "127.0.0.1" # optional per-service
+ports = [
+  { source = "8883", target = "8883" },
+  { source = "1883", target = "1883" }
+]
+


### PR DESCRIPTION
## Summary
- implement port-forwarding using client-go library
- auto-recreate port-forward whenever the connection closes
- allow configuring bind address globally, per context, or per entry

## Testing
- `go vet ./...` *(fails: Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6850f379935c832f8e1783c35fa59f20