### PR TITLE
Fix inversion of source and target ports during forwarding

### DIFF
--- a/internal/port_forward.go
+++ b/internal/port_forward.go
@@ -62,7 +62,9 @@ type Selector struct {
 	Address   string    `toml:"address,omitempty"`
 }
 
-// PortMap represents a port-forward mapping (source -> target)
+// PortMap represents a port-forward mapping (source -> target).
+// Note: the configuration labels `source` and `target` are inverted compared to the
+// Kubernetes port-forward CLI semantics, so the code compensates for that here.
 type PortMap struct {
 	Source string `toml:"source"`
 	Target string `toml:"target"`
@@ -206,7 +208,7 @@ func portForwardLabel(clientset *kubernetes.Clientset, cfg *rest.Config, context
 func maintainPortForward(cfg *rest.Config, contextName, namespace, podName string, ports []PortMap, address string) {
 	portArgs := make([]string, len(ports))
 	for i, p := range ports {
-		portArgs[i] = fmt.Sprintf("%s:%s", p.Source, p.Target)
+		portArgs[i] = fmt.Sprintf("%s:%s", p.Target, p.Source)
 	}
 	for {
 		if err := startPortForward(cfg, contextName, namespace, podName, address, portArgs); err != nil {


### PR DESCRIPTION
## Summary
- ensure port mappings interpret the configured source and target values in the correct direction
- document the configuration quirk around inverted source/target labels

## Testing
- go test ./... *(fails: hangs, interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_6905b3143668832f867da373f1a20eaa